### PR TITLE
Correct a sign in Bluestein, use some exact factors.

### DIFF
--- a/src/ctfft.jl
+++ b/src/ctfft.jl
@@ -501,7 +501,7 @@ struct TwiddleBluesteinStep{T} <: TwiddleStep{T}
         b = bluestein_b(T, ωpow, forward, r, r2)
         B = p * b
         new(r, m,
-            T[ωpow(T, n, (-1)^forward * mod(j1*k2,n)) for j1=1:r-1, k2=0:m-1],
+            T[ωpow(T, n, -(-1)^forward * mod(j1*k2,n)) for j1=1:r-1, k2=0:m-1],
             r2, p, a, A, b, B, forward)
     end
 end

--- a/src/ctfft.jl
+++ b/src/ctfft.jl
@@ -46,6 +46,9 @@ plan_inv(p::CTPlan{T}) where T =
 
 # steps for pregenerated kernels:
 function ωpow(T::Type{<:Complex}, n, i)
+    if mod(4i,n) == 0
+        return T(0.0+(-1im)^(4i ÷ n))
+    end
     Tr = promote_type(Float64, fieldtype(T, 1))
     twopi_n = -2(π/convert(Tr,n))
     exp((twopi_n*i)*im)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,39 +4,61 @@ using Test, LinearAlgebra, OffsetArrays
 
 include("symbolic.jl")
 
-function testdft(x::AbstractVector{T}) where T<:Union{Real,Complex}
+function testdft(x::AbstractVector{T},forward=true) where T<:Union{Real,Complex}
     Tr = real(float(T))
-    Tc = complex(float(T))
+    Tc = Complex{BigFloat}
     y = similar(x, Tc)
     N = length(x)
+    d = big(π)*2/big(0.0+N)
+    ifac = (-1)^forward
     for (k1, yind) in enumerate(eachindex(y))
         fct = zero(Tr)
         yk  = zero(Tc)
         for xi in x
-            yk  += xi*complex(cos(fct), -sin(fct))
-            fct += one(Tr)/N*(k1 - 1)*2*π
+            yk  += xi*complex(cos(fct), ifac * sin(fct))
+            fct += d*(k1 - 1)
         end
         y[yind] = yk
     end
     return y
 end
 
-@testset "Multiplication of size: $sz" for sz in [collect(fft_kernel_sizes); 511; 512; 513]
-  @testset "Real plan" begin
-      xr = rand(sz)
-      @test FourierTransforms.fft(xr) ≈ testdft(xr)
-      p = FourierTransforms.plan_fft(xr)
-      @test p*xr == FourierTransforms.fft(xr)
-      @test p\(p*xr) ≈ xr
-  end
+@testset "Type $T" for T in [Float64, BigFloat]
+    @testset "Multiplication of size: $sz" for sz in [collect(2:16)...,18,30,105,121]
+        @testset "Real plan" begin
+            xr = rand(sz)
+            @test FourierTransforms.fft(xr) ≈ testdft(xr)
+            p = FourierTransforms.plan_fft(xr)
+            @test p*xr == FourierTransforms.fft(xr)
+            @test p\(p*xr) ≈ xr
+        end
 
-  @testset "Complex plan applied to $atype" for (atype, x) in (
-      ("Vector", rand(Complex{Float64}, sz)),
-      ("OffsetVector", OffsetArray(rand(Complex{Float64}, sz), 0:(sz - 1)))
-  )
-      p = FourierTransforms.plan_fft(x)
-      @test mul!(similar(x), p, x) == p*x
-      @test p*x ≈ testdft(x)
-      @test p\(p*x) ≈ x
-  end
+        @testset "Complex plan applied to $atype" for (atype, offset) in (
+            ("Vector", false),
+            ("OffsetVector", true)
+            )
+            # if T=BigFloat, we want to check against a better standard
+            setprecision(BigFloat, 192)
+            if offset
+                x = OffsetArray(rand(Complex{T}, sz), 0:(sz - 1))
+            else
+                x = rand(Complex{T}, sz)
+            end
+            small = eps(T)
+            for forward in (true, false)
+                if forward
+                    p = FourierTransforms.plan_fft(x)
+                else
+                    p = FourierTransforms.plan_bfft(x)
+                end
+                y = p*x
+                @test mul!(similar(x), p, x) == y
+                setprecision(BigFloat, 256)
+                z = testdft(x, forward)
+                u = Float64(maximum(abs.(y-z)) / (small*sz*log2(sz)))
+                @test u < 2
+                @test p\(p*x) ≈ x
+            end
+        end
+    end
 end


### PR DESCRIPTION
This change corrects a sign in the twiddle code (fixing #10) and uses exact factors for n=4, allowing for better precision.

To be clear, this addresses problems with the 1D transforms with unit stride.  I think there are still troubles with non-unit stride.